### PR TITLE
fix: pass prompt via stdin to avoid "Argument list too long" on large PRs

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -360,9 +360,13 @@ run_gemini() {
     
     # Run Gemini CLI and capture output
     set +e  # Temporarily disable exit on error to capture exit code
-    
-    # Just use tee to show and save output - simple and effective
-    gemini -y -m "$GEMINI_MODEL" --prompt "$(cat "$prompt_file")" 2>&1 | tee /tmp/validation-full-output.md
+
+    # Feed the prompt via stdin, NOT as an argv argument. A large PR diff makes
+    # the prompt exceed the kernel's per-argument cap (MAX_ARG_STRLEN, 128KB on
+    # Linux) → "Argument list too long" (exit 126). gemini reads piped stdin as
+    # the prompt when stdin is not a TTY (cli/src/gemini.tsx). `--prompt` is also
+    # deprecated upstream. `set -o pipefail` keeps $? as gemini's exit code.
+    gemini -y -m "$GEMINI_MODEL" < "$prompt_file" 2>&1 | tee /tmp/validation-full-output.md
     local exit_code=$?
     
     set -e  # Re-enable exit on error
@@ -450,7 +454,12 @@ run_opencode() {
     # Run OpenCode CLI and capture output
     set +e  # Temporarily disable exit on error to capture exit code
 
-    opencode run -m "$full_model" "$(cat "$prompt_file")" 2>&1 | tee /tmp/validation-full-output.md
+    # Feed the prompt via stdin, NOT as an argv argument. A large PR diff makes
+    # the prompt exceed the kernel's per-argument cap (MAX_ARG_STRLEN, 128KB on
+    # Linux) → "Argument list too long" (exit 126). opencode reads piped stdin as
+    # the message when stdin is not a TTY (cli/cmd/run.ts). `set -o pipefail`
+    # keeps $? as opencode's exit code through the tee pipe.
+    opencode run -m "$full_model" < "$prompt_file" 2>&1 | tee /tmp/validation-full-output.md
     local exit_code=$?
 
     set -e  # Re-enable exit on error


### PR DESCRIPTION
## Problem

`run_opencode` and `run_gemini` pass the entire prompt as a **single argv argument**:

```bash
opencode run -m "$full_model" "$(cat "$prompt_file")"      # line 453
gemini -y -m "$GEMINI_MODEL" --prompt "$(cat "$prompt_file")"  # line 365
```

On Linux the per-argument cap is `MAX_ARG_STRLEN` = 128 KB (`PAGE_SIZE × 32`). A PR with a large diff produces a 150 KB+ prompt, so the kernel rejects the exec with **`Argument list too long` (exit 126)** and validation hard-fails before the model is ever invoked.

Observed in the wild on a large PR (179 KB prompt):
```
/home/runner/.opencode/bin/opencode: Argument list too long
❌ OpenCode CLI failed (exit code: 126)
::error::Non-retryable error occurred.
```

## Fix

Feed the prompt through **stdin** instead. A piped stream has no per-argument size limit. Verified both CLIs read a non-TTY stdin as the prompt directly from their source:

- **opencode** — `packages/opencode/src/cli/cmd/run.ts`: `const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()` → used as the message when no positional arg is given.
- **gemini** — `packages/cli/src/gemini.tsx`: `if (!process.stdin.isTTY) stdinData = await readStdin()` → pushed as `--prompt`. (`--prompt` is also deprecated upstream, so this drops a deprecation too.)

`set -o pipefail` is already enabled, so `$?` still reflects the CLI's exit code through the `| tee` pipe — retry detection and exit-code handling are unchanged.

## Testing

- `bash -n scripts/validate.sh` — syntax clean.
- Confirmed a 179 KB argument triggers `Argument list too long` at exec on Linux, while the same payload over `< file` stdin has no limit.
- No behavioral change beyond prompt delivery: model, flags, output capture (`| tee`), retry loop, and exit-code semantics are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)