### PR TITLE
fix(ci): pin the OpenCode installer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,9 @@ jobs:
             echo "✅ $script syntax is valid"
           done
 
+      - name: Test Pinned OpenCode Installation
+        run: scripts/test-setup-opencode.sh
+
   test-templates:
     name: Validate Templates
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -734,6 +734,13 @@ The `allow-web-fetch` input controls whether the AI can download external resour
 
 ## 🐛 Troubleshooting
 
+### OpenCode installation is reproducible
+
+The action installs a pinned OpenCode CLI release through npm and verifies the
+reported version before validation starts. This avoids depending on an
+unverified remote installer archive and prevents transient CDN responses from
+being passed to `tar`. Consumers do not need to install OpenCode themselves.
+
 ### No Output from AI CLI
 
 **Symptom**: GitHub Action runs but shows no AI output or errors
@@ -1035,4 +1042,3 @@ MIT License - see [LICENSE](LICENSE) for details.
 - 💬 [Discussions](https://github.com/flowcore-io/usable-pr-validator/discussions)
 
 Made with ❤️ by [Flowcore](https://flowcore.io)
-

--- a/scripts/setup-opencode.sh
+++ b/scripts/setup-opencode.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 OPENCODE_PROVIDER="${OPENCODE_PROVIDER:-openrouter}"
+OPENCODE_VERSION="${OPENCODE_VERSION:-1.18.17}"
 
 echo "::group::Setting up OpenCode CLI + ${OPENCODE_PROVIDER}"
 
@@ -15,34 +16,34 @@ if [ -z "$SECRET_VALUE" ]; then
   exit 1
 fi
 
-# Install OpenCode CLI
-echo "Installing OpenCode CLI..."
-if ! command -v opencode &> /dev/null; then
-  curl -fsSL https://opencode.ai/install | bash
-
-  # The installer puts opencode in ~/.opencode/bin and updates .bashrc,
-  # but PATH changes from .bashrc don't apply to the current shell.
-  # Add known install locations to PATH for this session.
-  for dir in "$HOME/.opencode/bin" "$HOME/.local/bin"; do
-    if [ -f "$dir/opencode" ]; then
-      export PATH="$dir:$PATH"
-      # Also ensure subsequent steps have it (installer may already do this for GITHUB_PATH)
-      if [ -n "${GITHUB_PATH:-}" ]; then
-        echo "$dir" >> "$GITHUB_PATH"
-      fi
-      break
-    fi
-  done
-
-  if ! command -v opencode &> /dev/null; then
-    echo "::error::OpenCode CLI installation failed - command not found after install"
-    echo "Searched: ~/.opencode/bin, ~/.local/bin"
-    echo "PATH: $PATH"
-    exit 1
-  fi
+# Install an exact OpenCode version through npm. The previous remote install
+# script downloaded a release archive without verifying its content, so a CDN
+# error page could be piped into tar and fail with "not in gzip format".
+installed_version=""
+if command -v opencode &> /dev/null; then
+  installed_version="$(opencode --version 2>/dev/null || true)"
+  installed_version="${installed_version#v}"
 fi
 
-echo "✅ OpenCode CLI installed: $(opencode --version 2>/dev/null || echo 'version unknown')"
+if [ "$installed_version" != "$OPENCODE_VERSION" ]; then
+  echo "Installing OpenCode CLI ${OPENCODE_VERSION} with npm..."
+  npm install --global --no-audit --no-fund "opencode-ai@${OPENCODE_VERSION}"
+fi
+
+if ! command -v opencode &> /dev/null; then
+  echo "::error::OpenCode CLI installation failed - command not found after npm install"
+  echo "PATH: $PATH"
+  exit 1
+fi
+
+installed_version="$(opencode --version 2>/dev/null || true)"
+installed_version="${installed_version#v}"
+if [ "$installed_version" != "$OPENCODE_VERSION" ]; then
+  echo "::error::OpenCode CLI version mismatch: expected ${OPENCODE_VERSION}, got ${installed_version:-unknown}"
+  exit 1
+fi
+
+echo "✅ OpenCode CLI installed: ${installed_version}"
 
 # Determine the correct env var name for the provider
 # OpenCode expects provider-specific env vars (e.g., OPENROUTER_API_KEY, ANTHROPIC_API_KEY)

--- a/scripts/test-setup-opencode.sh
+++ b/scripts/test-setup-opencode.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+FAKE_BIN="${FIXTURE_DIR}/bin"
+NPM_LOG="${FIXTURE_DIR}/npm.log"
+MOCK_OPENCODE_VERSION="1.18.17"
+export FAKE_BIN NPM_LOG MOCK_OPENCODE_VERSION
+
+cleanup() {
+  rm -rf "$FIXTURE_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+
+cat > "${FAKE_BIN}/npm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$NPM_LOG"
+cat > "${FAKE_BIN}/opencode" <<'OPENCODE'
+#!/usr/bin/env bash
+printf '%s\n' "$MOCK_OPENCODE_VERSION"
+OPENCODE
+chmod +x "${FAKE_BIN}/opencode"
+EOF
+chmod +x "${FAKE_BIN}/npm"
+
+run_setup() {
+  PATH="${FAKE_BIN}:/usr/bin:/bin" \
+    OPENCODE_API_KEY="test-key" \
+    OPENCODE_VERSION="1.18.17" \
+    "$SCRIPT_DIR/setup-opencode.sh"
+}
+
+run_setup
+grep -Fxq -- "install --global --no-audit --no-fund opencode-ai@1.18.17" "$NPM_LOG"
+
+: > "$NPM_LOG"
+run_setup
+if [ -s "$NPM_LOG" ]; then
+  echo "Expected an exact preinstalled OpenCode version to skip npm installation" >&2
+  exit 1
+fi
+
+cat > "${FAKE_BIN}/opencode" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "1.18.16"
+EOF
+chmod +x "${FAKE_BIN}/opencode"
+
+run_setup
+grep -Fxq -- "install --global --no-audit --no-fund opencode-ai@1.18.17" "$NPM_LOG"
+
+echo "✅ setup-opencode.sh installs and verifies the pinned CLI version"


### PR DESCRIPTION
## What changed

- replace the unverified remote OpenCode installer pipeline with `npm install --global --no-audit --no-fund opencode-ai@1.18.17`
- reuse an already installed exact version and reject version mismatches
- add a focused shell test covering missing, matching, and mismatched installations
- document the reproducible installer behavior

## Why

`flowcore-io/usable#858` failed standards validation twice before validation began. In both jobs, the remote installer downloaded a payload that was not gzip data, while the parallel security validator happened to install the same version successfully. Pinning the official npm package makes the dependency reproducible and lets npm verify package integrity.

## Verification

- `bash -n scripts/setup-opencode.sh scripts/test-setup-opencode.sh`
- `scripts/test-setup-opencode.sh`
- YAML parsing for `action.yml` and `.github/workflows/test.yml`
- `git diff --check`

`scripts/test-local-quick.sh` requires `GEMINI_SERVICE_ACCOUNT_KEY`, which is unavailable locally; the repository's secret-backed PR integration jobs provide that evidence.